### PR TITLE
Fix event listener cleanup in guntanks

### DIFF
--- a/lib/guntanks.js
+++ b/lib/guntanks.js
@@ -161,7 +161,7 @@ class Game {
   startTurns () {
     this.turn.play();
     window.UI.disabled = false;
-    window.removeEventListener('keypress', this.shotKeys);
+    window.removeEventListener('keypress', this.shotKey);
     window.removeEventListener('keypress', this.shotKeyss);
     if (this.turnCounter === 1) window.tanks = window.tanks.sort((a,b) => a.delay - b.delay);
 
@@ -170,14 +170,15 @@ class Game {
     this.currentTank.distance = 0;
     document.getElementById('prev-power').style.left = `${this.currentTank.prevPower}px`;
 
-    const shotKey = (e) => { e.key;
-      if (e.key == '1') this.currentTank.switchShot1(); //switch shot event listener
-      if (e.key == '2') this.currentTank.switchShot2(); //switch shot event listener
+    this.shotKey = (e) => {
+      if (e.key == '1') this.currentTank.switchShot1();
+      if (e.key == '2') this.currentTank.switchShot2();
     };
 
-    const shotKeyss = (e) => {
-      const keyPress = e.key;
-      if (e.key == '3' && this.currentTank.ssCooldown <= 0) this.currentTank.switchShotss(); //switch shot event listener
+    this.shotKeyss = (e) => {
+      if (e.key == '3' && this.currentTank.ssCooldown <= 0) {
+        this.currentTank.switchShotss();
+      }
     };
 
     if (this.roundCounter !== 0 && this.roundCounter % 3 === 0 && this.turnCounter === 1) { //change wind every 3 rounds
@@ -193,12 +194,12 @@ class Game {
       document.getElementById('turn-queue').appendChild(li);
     }
 
-    window.addEventListener('keypress', shotKey);
+    window.addEventListener('keypress', this.shotKey);
     document.getElementById('shot1').onclick = this.currentTank.switchShot1; //switch shot event listener
     document.getElementById('shot2').onclick = this.currentTank.switchShot2; //switch shot event listener
     if (this.currentTank.ssCooldown <= 0) {
 
-      window.addEventListener('keypress', shotKeyss);
+      window.addEventListener('keypress', this.shotKeyss);
       document.getElementById('ss').onclick = this.currentTank.switchShotss; //switch shot event listener
       document.getElementById('ss').style.background = 'rgb(246, 216, 89)'; //switch shot event listener
     } else {


### PR DESCRIPTION
## Summary
- fix typo causing keypress listeners to accumulate

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842bd304d688330b6bfa13e3eb96048

## Summary by Sourcery

Fix keypress event listener management for tank shots to prevent accumulating listeners across turns.

Bug Fixes:
- Store shot control handlers as Game instance properties and correct the removeEventListener typo to properly detach them.
- Prevent duplicate keypress listeners by defining handlers as this.shotKey and this.shotKeyss and using matching references for add/remove.