### PR TITLE
Align SS delay docs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Guntanks! is a simplified clone of popular turn based tank games like Worms and 
 ### Delay
 * Every second you take during your turn adds to your delay which determines when your next turn will happen.
 * Firing shots also adds to your delay.
-* Shot 1 adds 750, Shot 2 adds 900, and your Special Shot (SS) will add 1330 to your delay.
+* Shot 1 adds 750, Shot 2 adds 900, and your Special Shot (SS) will add 1300 to your delay.
 * The current turn order and delay for each player is displayed in the Delay Queue.
 
 ### Shells


### PR DESCRIPTION
## Summary
- update Special Shot delay explanation to match implementation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842c002cb6c8330a27e82ca1f427ffc

## Summary by Sourcery

Documentation:
- Corrected Special Shot delay in README from 1330 to 1300 to match code